### PR TITLE
LPS-69427 Current JAX-RS bundle prevents from using bean validation standard in JAX-RS

### DIFF
--- a/modules/apps/foundation/portal-remote/portal-remote-cxf-jaxrs-common/bnd.bnd
+++ b/modules/apps/foundation/portal-remote/portal-remote-cxf-jaxrs-common/bnd.bnd
@@ -19,8 +19,6 @@ Fragment-Host: com.liferay.portal.remote.cxf.common
 Import-Package:\
 	!com.sun.*,\
 	\
-	!javax.validation.*,\
-	\
 	!net.sf.cglib.proxy.*,\
 	\
 	!org.apache.abdera.*,\

--- a/modules/apps/foundation/portal-remote/portal-remote-cxf-jaxrs-common/build.gradle
+++ b/modules/apps/foundation/portal-remote/portal-remote-cxf-jaxrs-common/build.gradle
@@ -1,6 +1,11 @@
+task deployDependencies(type: Copy)
+
+import com.liferay.gradle.util.copy.RenameDependencyClosure
+
 dependencies {
 	provided group: "javax.annotation", name: "javax.annotation-api", version: "1.2"
 	provided group: "javax.json", name: "javax.json-api", version: "1.0"
+	provided group: "javax.validation", name: "validation-api", version: "1.1.0.Final"
 	provided group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.0.1"
 	provided group: "org.apache.cxf", name: "cxf-core", version: "3.0.3"
 	provided group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.0.3"
@@ -10,4 +15,32 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
 	provided group: "org.osgi", name: "org.osgi.service.http", version: "1.2.1"
 	provided group: "org.osgi", name: "org.osgi.service.http.whiteboard", version: "1.0.0"
+}
+
+deploy {
+	finalizedBy deployDependencies
+}
+
+deployDependencies {
+	boolean keepDependencyVersions = Boolean.getBoolean("deploy.dependencies.keep.versions")
+
+	ext {
+		autoClean = false
+	}
+
+	from configurations.provided
+
+	include "validation-*.jar"
+
+	into {
+		liferay.deployDir
+	}
+
+	outputs.upToDateWhen {
+		false
+	}
+
+	if (!keepDependencyVersions) {
+		rename new RenameDependencyClosure(project, configurations.provided.name)
+	}
 }


### PR DESCRIPTION
Hi Andrea,

can you please review the changes? There is nothing to check from my side.

Thanks!

https://issues.liferay.com/browse/LPS-69427