### PR TITLE
LPS-70451 Add xmlbean as thirdparty module to exclude org.w3c.* conflict

### DIFF
--- a/modules/third-party/org-apache-xmlbean/bnd.bnd
+++ b/modules/third-party/org-apache-xmlbean/bnd.bnd
@@ -1,0 +1,7 @@
+Bundle-SymbolicName: org.apache.xmlbeans
+Bundle-Version: 2.5.0.LIFERAY-PATCHED-1
+-includeresource:\
+	@xmlbeans-[0-9]*.jar!/org/apache/*,\
+	@xmlbeans-[0-9]*.jar!/repackage/*,\
+	@xmlbeans-[0-9]*.jar!/schemaorg_apache_xmlbeans/*,\
+	@xmlbeans-[0-9]*.jar!/*.txt,\

--- a/modules/third-party/org-apache-xmlbean/build.gradle
+++ b/modules/third-party/org-apache-xmlbean/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	provided group: "org.apache.xmlbeans", name: "xmlbeans", transitive: false, version: "2.5.0"
+}


### PR DESCRIPTION
Hi Andrea, this is the last one of the thirdparty jars that only requires removing, thanks!