### PR TITLE
LPS-73271 Print FindSecurityBugsPlugin messages when the task fails

### DIFF
--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/FindSecurityBugsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/FindSecurityBugsPlugin.java
@@ -241,7 +241,7 @@ public class FindSecurityBugsPlugin implements Plugin<Project> {
 
 					if (logger.isLifecycleEnabled()) {
 						logger.lifecycle(
-							"Find Security Bugs report saved to {}.",
+							"Find Security Bugs report saved to {}",
 							outputFile.getAbsolutePath());
 					}
 				}

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/FindSecurityBugsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/internal/FindSecurityBugsPlugin.java
@@ -16,6 +16,7 @@ package com.liferay.gradle.plugins.defaults.internal;
 
 import com.liferay.gradle.plugins.defaults.internal.util.FileUtil;
 import com.liferay.gradle.plugins.defaults.internal.util.GradleUtil;
+import com.liferay.gradle.plugins.defaults.tasks.ActionTask;
 import com.liferay.gradle.plugins.defaults.tasks.WriteFindBugsProjectTask;
 import com.liferay.gradle.plugins.jasper.jspc.CompileJSPTask;
 import com.liferay.gradle.plugins.jasper.jspc.JspCPlugin;
@@ -147,7 +148,7 @@ public class FindSecurityBugsPlugin implements Plugin<Project> {
 
 		Project project = writeFindBugsProjectTask.getProject();
 
-		JavaExec javaExec = GradleUtil.addTask(
+		final JavaExec javaExec = GradleUtil.addTask(
 			project, FIND_SECURITY_BUGS_TASK_NAME, JavaExec.class);
 
 		javaExec.args(
@@ -230,14 +231,17 @@ public class FindSecurityBugsPlugin implements Plugin<Project> {
 
 			});
 
-		javaExec.doLast(
+		ActionTask printReportFileNameTask = GradleUtil.addTask(
+			project, "printReportFileName", ActionTask.class);
+
+		printReportFileNameTask.setAction(
 			new Action<Task>() {
 
 				@Override
 				public void execute(Task task) {
-					Logger logger = task.getLogger();
+					Logger logger = javaExec.getLogger();
 
-					File outputFile = outputFileGetter.transform(task);
+					File outputFile = outputFileGetter.transform(javaExec);
 
 					if (logger.isLifecycleEnabled()) {
 						logger.lifecycle(
@@ -247,6 +251,8 @@ public class FindSecurityBugsPlugin implements Plugin<Project> {
 				}
 
 			});
+
+		javaExec.finalizedBy(printReportFileNameTask);
 
 		javaExec.dependsOn(writeFindBugsProjectTask);
 

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/tasks/ActionTask.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/tasks/ActionTask.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.gradle.plugins.defaults.tasks;
+
+import org.gradle.api.Action;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * @author Tomas Polesovsky
+ */
+public class ActionTask extends DefaultTask {
+
+	@TaskAction
+	public void accept() throws Exception {
+		_action.execute(this);
+	}
+
+	public void setAction(Action<Task> action) {
+		_action = action;
+	}
+
+	private Action<Task> _action;
+
+}


### PR DESCRIPTION
Hi Andrea,

I want to fail `findSecurityBugs` task for modules I already reviewed and a new security regression appears (will be separate PR). 

But when I fail it then the message with output file name is not printed because actions in `javaExec.doLast()` are not executed. So I create the new task for `finalizeBy`, not sure if it's the best way though.

And I removed the trailing period from the file name. The message with the file name is there for copy & paste, so it makes sense to print it as-is. I cannot simply copy & paste the name into browser and must edit it every time. `findBugs` task also prints it without period.

Thanks.

https://issues.liferay.com/browse/LPS-73271